### PR TITLE
Restore replying functionality inside Flowdock while keeping avatars.

### DIFF
--- a/lookout/services/flowdock.py
+++ b/lookout/services/flowdock.py
@@ -73,7 +73,7 @@ class Service(ServiceBase):
                 'project': self._strip(payload['product']['name']),
                 'format': 'html',
                 'tags': payload['attributes']['tags'],
-                'link': payload['attributes']['short_url']
+                'link': payload['attributes']['short_url'],
                 'reply_to': payload['attributes']['email']['discussion']
             }
 
@@ -112,7 +112,7 @@ class Service(ServiceBase):
                 'project': self._strip(payload['product']['name']),
                 'format': 'html',
                 'tags': payload['attributes']['item']['tags'],
-                'link': payload['attributes']['item']['short_url']
+                'link': payload['attributes']['item']['short_url'],
                 'reply_to': payload['attributes']['item']['email']['discussion']
             }
 


### PR DESCRIPTION
Now (at least in theory) you can still respond directly inside Flowdock to have the content reflected back in the Sprint.ly systems.
At fc1dca7 I wasn't aware than the email changes would break this but after reading that it was a blocking point in #1, I decided to fix it properly.
Comments on Flowdock should now get routed back to Sprint.ly. 
Please confirm this is the case and close this.
