### PR TITLE
Added an icon_url.

### DIFF
--- a/lookout/services/slack.py
+++ b/lookout/services/slack.py
@@ -50,7 +50,7 @@ class Service(WebHookService):
         default_data.update(attachment)
 
         return {
-            'icon_url': 'https://s3.amazonaws.com/sprintly-marketing-assets/integrations/slack-bot-icon.png'
+            'icon_url': 'https://s3.amazonaws.com/sprintly-marketing-assets/integrations/slack-bot-icon.png',
             'attachments': [default_data]
         }
 

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -36,6 +36,7 @@ def test_get_post_data(payload):
         mock_get_attachment.return_value = {}
         post_data = srv.get_post_data(payload)
         assert post_data.has_key('attachments')
+        assert post_data.has_key('icon_url')
         mock_get_attachment.assert_called_with(payload)
 
 @pytest.mark.parametrize('payload', all_payloads)


### PR DESCRIPTION
#### What's this PR do?

Adds an icon to messages we post to Slack per [attachments docs](https://api.slack.com/docs/attachments) and [chat message docs](https://api.slack.com/methods/chat.postMessage).
#### Where should the reviewer start?

See the `default_data` dict we're now sending Slack.
#### How should this be manually tested?

n/a
#### Any background context you want to provide?

When we first integrated with Slack they didn't allow you to post an icon along with it. Now you can.
#### What are the relevant tickets?

n/a
#### Screenshots (if appropriate)

![2014-08-18 at 11 27 am](https://cloud.githubusercontent.com/assets/37667/3955827/517549c4-2705-11e4-9342-7d5f073e0b26.png)
#### What gif best describes this PR or how it makes you feel?

![](http://media2.giphy.com/media/8TRfrgKe1ndE4/giphy.gif)
#### Definition of Done:
- [x] Is there appropriate test coverage? (e.g. ChefSpec, Mocha/Chai, Python, etc.)
- [x] Does this PR require a Selenium test? (e.g. Browser-specific bugs or complicated UI bugs)
- [x] Does this PR require a regression test? All fixes require a regression test.
- [x] Does this PR require a blog post? If so, ensure marketing has signed off on content.
- [x] Does the [knowledge base](https://sprint.ly/docs) need to be updated?
- [x] Does this add new dependencies? If so, does Chef, M4, or PIP requirements need to be updated?
- [x] Will this feature require a new piece of infrastructure be implemented?
- [x] Are any new services fully automated in Chef?
- [x] Are there ChefSpec tests for the new Chef recipes/cookbooks?
- [x] Does this PR require new Mixpanel or GA events?
- [x] Is there appropriate logging included?
