### PR TITLE
Add support for a new service option `notify_on_actions` that will allow the Sprint.ly user to specify which actions should trigger a given service

### DIFF
--- a/lookout/services/slack.py
+++ b/lookout/services/slack.py
@@ -13,13 +13,20 @@ class Service(WebHookService):
     Visit the following URL for Slack configuration documentation:
     `https://my.slack.com/services/new/incoming-webhook`
     """
-    @listen_to('*.created')
+    @listen_to('*.*')
     def send(self, payload):
         options = self.options.copy()
 
         try:
             url = options.pop('url')
         except KeyError:
+            return
+
+        # Figure out which actions the user wants to be notified about.  We default to 'created' to support the prior
+        # Sprint.ly behavior.
+        notify_on_actions = options.get('notify_on_actions', ['created'])
+
+        if payload.get('action', 'created') not in notify_on_actions:
             return
 
         data = self.get_post_data(payload)

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -2,6 +2,7 @@
 Fixture data, uses real model data pulled down via the Django ORM
 and uses `wasatch.utils.model_to_json` with expand=True
 """
+import copy
 
 fake_product = {
     'admin': False,
@@ -108,6 +109,15 @@ fake_item_payload = {
         'type': 'defect'
     }
 }
+
+fake_item_created_payload = copy.deepcopy(fake_item_payload)
+fake_item_created_payload['action'] = 'created'
+
+fake_item_updated_payload = copy.deepcopy(fake_item_payload)
+fake_item_updated_payload['action'] = 'updated'
+
+fake_item_deleted_payload = copy.deepcopy(fake_item_payload)
+fake_item_deleted_payload['action'] = 'deleted'
 
 fake_block_payload = {
     'model': 'Block',
@@ -548,5 +558,8 @@ all_payloads = [
     fake_item_payload,
     fake_block_payload,
     fake_favorite_payload,
-    fake_deploy_payload
+    fake_deploy_payload,
+    fake_item_created_payload,
+    fake_item_updated_payload,
+    fake_item_deleted_payload
 ]

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -21,7 +21,12 @@ def test_flowdock_sends(payload):
     with patch('requests.post') as mock_requests_post:
         service = FlowdockService(options)
         service.send(payload)
-        assert mock_requests_post.called
+
+        # Flowdock only supports the 'created' action
+        if payload.get('action', 'created') == 'created':
+            assert mock_requests_post.called
+        else:
+            assert not mock_requests_post.called
 
 @pytest.mark.parametrize('payload', all_payloads)
 def test_hipchat_sends(payload):
@@ -33,7 +38,12 @@ def test_hipchat_sends(payload):
     with patch('requests.post') as mock_requests_post:
         service = HipchatService(options)
         service.send(payload)
-        assert mock_requests_post.called
+
+        # Hipchat only supports the 'created' action
+        if payload.get('action', 'created') == 'created':
+            assert mock_requests_post.called
+        else:
+            assert not mock_requests_post.called
 
 @pytest.mark.parametrize('payload', all_payloads)
 def test_webhook_sends(payload):
@@ -53,7 +63,7 @@ def test_webhook_sends(payload):
 
             assert mock_urllib2_request.call_count == len(options['urls'])
             assert mock_urllib2_request.call_args[0][0] == options['urls'][0]
-            mock_urllib2_urlopen.call_args[0][0] == mock_request
+            assert mock_urllib2_urlopen.call_args[0][0] == mock_request
 
 @pytest.mark.parametrize('payload', all_payloads)
 def test_webhook_requires_urls(payload):
@@ -82,9 +92,13 @@ def test_slack_sends(payload):
             service = SlackService(options)
             service.send(payload)
 
-            assert mock_urllib2_request.called
-            assert mock_urllib2_request.call_args[0][0] == options['url']
-            mock_urllib2_urlopen.call_args[0][0] == mock_request
+            # Test legacy configuration where only the 'created' action was supported
+            if payload.get('action', 'created') == 'created':
+                assert mock_urllib2_request.called
+                assert mock_urllib2_request.call_args[0][0] == options['url']
+                assert mock_urllib2_urlopen.call_args[0][0] == mock_request
+            else:
+                assert not mock_urllib2_request.called
 
 @pytest.mark.parametrize('payload', all_payloads)
 def test_slack_requires_url(payload):
@@ -99,3 +113,31 @@ def test_slack_requires_url(payload):
             assert not mock_urllib2_request.called
             assert not mock_urllib2_urlopen.called
 
+@pytest.mark.parametrize('payload', all_payloads)
+def test_slack_configurable_by_action(payload):
+    options = {
+        'url': 'https://something.slack.com/services/hooks/incoming-webhook?token=sometoken',
+        'notify_on_actions': None
+    }
+
+    supported_actions = ('created', 'updated', 'deleted')
+
+    for action in supported_actions:
+
+        options['notify_on_actions'] = [action]
+
+        with patch('urllib2.Request') as mock_urllib2_request:
+            with patch('urllib2.urlopen') as mock_urllib2_urlopen:
+                mock_request = Mock()
+                mock_urllib2_request.return_value = mock_request
+
+                service = SlackService(options)
+                service.send(payload)
+
+                if payload.get('action', 'created') == action:
+                    assert mock_urllib2_request.called
+                    assert mock_urllib2_request.call_args[0][0] == options['url']
+                    assert mock_urllib2_urlopen.call_args[0][0] == mock_request
+                else:
+                    assert not mock_urllib2_request.called
+                    assert not mock_urllib2_urlopen.called


### PR DESCRIPTION
At this time, support for this new option has only been added to the Slack service, and appropriate tests/fixtures have been added as well.

The new option, `notify_on_actions` should be a list of zero or more actions (i.e. "created", "updated", "deleted").